### PR TITLE
Add ability to ignore auth for specific routes [INT-223]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,8 @@ Release 1.1.3
 
 Release 1.1.4
 - Fix issues with Datastore typings
+
+Release 1.1.5
+- Changes 
+  - Remove authentication support for parsing JSON object in state query param
+  - Add ability to bypass auth for specific routes

--- a/helpers/jwt.js
+++ b/helpers/jwt.js
@@ -22,24 +22,11 @@ exports.parse = function (req) {
   // in just in case - won't hurt anything
   const authHeader = req.headers && (req.headers.Authorization || req.headers.authorization);
   const authQuery = req.query.jwt_token;
-  // add a check for an embedded jwt_token in the state query param also (oauth spec)
-  const stateQuery = req.query.state;
 
   if (authHeader)
     return authHeader.split('Bearer ')[1];
   if (authQuery)
     return authQuery;
-  if (stateQuery) {
-    // for auth purposes, stringified json
-    try {
-      const obj = JSON.parse(stateQuery);
-      if (obj.jwt_token) {
-        return obj.jwt_token;
-      }
-    } catch (e) {
-      console.error(`state param did not parse as JSON ${e}`);
-    }
-  }
 
   throw new Error('No JWT token provided.');
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -257,6 +257,11 @@ declare module '@dronedeploy/function-wrapper' {
     authRequired: boolean;
 
     /**
+     * Defines specific routes that will be ignored during authorization checks
+     */
+    ignoreAuthRoutes: string[];
+
+    /**
      * Indicates whether to mock the token; useful for development purposes. If this is set to true, then
      * authRequired must be set to false.
      */

--- a/index.js
+++ b/index.js
@@ -42,11 +42,18 @@ module.exports = (config, req, res, cb) => {
       res.status(200).send();
   }
 
+  const ignoreAuthForRoute = (route) => {
+    if (config.ignoreAuthRoutes && config.ignoreAuthRoutes.length > 0) {
+      return config.ignoreAuthRoutes.contains(route);
+    }
+    return false;
+  };
+
   let token;
   try {
     token = jwt.parse(req);
   } catch (e) {
-    if (config.authRequired) {
+    if (config.authRequired && !ignoreAuthForRoute(req.path)) {
       res.status(401).send({
         error: {
           'message': 'Could not find user credentials.'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dronedeploy/function-wrapper",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Public GraphQL API and Wrapper for Dronedeploy Functions",
   "main": "index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
## Work Done
- Remove `state` query parameter authentication processing
- Add ability to bypass authentication for specific routes via configuration
- Update types
- Update change log
- Increment to version 1.1.5 (intend to publish after this goes through)

### Reason for Changes
The state parameter will vary greatly in length depending on the JWT token size, and it is possible that OAuth providers will throw errors when the entire url (or `state` param) exceed a certain size.  These changes allow us to work with these limitations.