### PR TITLE
Increase version to 1.1.7, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,9 @@ Release 1.1.5
 Release 1.1.6
 - Changes
   - Bug fix on array element check for route check
+
+Release 1.1.7
+- Changes
+  - Simplified function-wrapper `bootstrap` function (non-backwards compatable)
+  - Update dependencies to address security vulnerability
+  - Allow definition of custom CORS headers in `CORS_HEADERS` environment variable

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dronedeploy/function-wrapper",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@dronedeploy/function-wrapper",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Public GraphQL API and Wrapper for Dronedeploy Functions",
+  "homepage": "https://github.com/dronedeploy/function-wrapper",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dronedeploy/function-wrapper"
+  },
   "main": "index.js",
   "types": "./index.d.ts",
   "scripts": {


### PR DESCRIPTION
### Work Done
- Increase version in `package.json`
- Add `homepage` and `repository` fields to package.json
- Update CHANGELOG