### PR TITLE
[INT-2193] Fixed support for ignored auth routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,7 @@ Release 1.1.7
   - Simplified function-wrapper `bootstrap` function (non-backwards compatable)
   - Update dependencies to address security vulnerability
   - Allow definition of custom CORS headers in `CORS_HEADERS` environment variable
+
+Release 1.2.5
+- Changes
+  - Fixed support for ignored auth routes

--- a/README.md
+++ b/README.md
@@ -182,10 +182,20 @@ Configuration in `.env` file:
 - `AUTH_REQUIRED=<boolean_string>`, set to false for testing or if your function does not use dd's api's
 - `MOCK_TOKEN=<boolean_string>`, // set to true to allow token
 - `CORS_HEADERS=<comma_separated_headers>` // add custom headers that should be allowed past cors here
+- `IGNORE_AUTH_ROUTES=<comma_separated_routes>` // add routes to ignore while checking auth
 
 Example
 ```
 AUTH_REQUIRED=false
 MOCK_TOKEN=true
 CORS_HEADERS=x-custom-token,x-some-other-allowed-header
+IGNORE_AUTH_ROUTES=/route/1,/route/2
+```
+
+These env variables can be also set in the code:
+```javascript
+process.env.AUTH_REQUIRED = false
+process.env.MOCK_TOCKEN = true
+process.env.CORS_HEADERS = ['x-custom-token', 'x-some-other-allowed-header']
+process.env.AUTH_REQUIRED = ['/route/1', '/route/2']
 ```

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -5,7 +5,7 @@ module.exports = {
 function getBootstrapConfig() {
   return {
     authRequired: strToBool(process.env.AUTH_REQUIRED, true),
-    cors: { headers: strToArray('CORS_HEADERS').filter(Boolean) },
+    cors: { headers: strToArray('CORS_HEADERS') },
     mockToken: strToBool(process.env.MOCK_TOKEN, false),
     ignoreAuthRoutes: strToArray('IGNORE_AUTH_ROUTES'),
   };
@@ -16,5 +16,5 @@ function strToBool(text, defaultValue) {
 }
 
 function strToArray(envVarName) {
-  return (process.env[envVarName] || '').split(',')
+  return (process.env[envVarName] || '').split(',').filter(Boolean);
 }

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -5,11 +5,16 @@ module.exports = {
 function getBootstrapConfig() {
   return {
     authRequired: strToBool(process.env.AUTH_REQUIRED, true),
-    cors: { headers: (process.env.CORS_HEADERS || '').split(',').filter(Boolean) },
+    cors: { headers: strToArray('CORS_HEADERS').filter(Boolean) },
     mockToken: strToBool(process.env.MOCK_TOKEN, false),
+    ignoreAuthRoutes: strToArray('IGNORE_AUTH_ROUTES'),
   };
 }
 
 function strToBool(text, defaultValue) {
   return text ? text.toLowerCase() === 'true' : defaultValue;
+}
+
+function strToArray(envVarName) {
+  return (process.env[envVarName] || '').split(',')
 }

--- a/helpers/config.js
+++ b/helpers/config.js
@@ -5,9 +5,9 @@ module.exports = {
 function getBootstrapConfig() {
   return {
     authRequired: strToBool(process.env.AUTH_REQUIRED, true),
-    cors: { headers: strToArray('CORS_HEADERS') },
+    cors: { headers: commaDelimitedStringToArray('CORS_HEADERS') },
     mockToken: strToBool(process.env.MOCK_TOKEN, false),
-    ignoreAuthRoutes: strToArray('IGNORE_AUTH_ROUTES'),
+    ignoreAuthRoutes: commaDelimitedStringToArray('IGNORE_AUTH_ROUTES'),
   };
 }
 
@@ -15,6 +15,6 @@ function strToBool(text, defaultValue) {
   return text ? text.toLowerCase() === 'true' : defaultValue;
 }
 
-function strToArray(envVarName) {
+function commaDelimitedStringToArray(envVarName) {
   return (process.env[envVarName] || '').split(',').filter(Boolean);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dronedeploy/function-wrapper",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Public GraphQL API and Wrapper for Dronedeploy Functions",
   "homepage": "https://github.com/dronedeploy/function-wrapper",
   "repository": {


### PR DESCRIPTION
https://dronedeploy.atlassian.net/browse/INT-2193

Added / fixed support for ignored auth routes which was missed when we changed our approach from `config.json` to `process.env`