### PR TITLE
Bump version to 1.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dronedeploy/function-wrapper",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Public GraphQL API and Wrapper for Dronedeploy Functions",
   "homepage": "https://github.com/dronedeploy/function-wrapper",
   "repository": {


### PR DESCRIPTION
This version bump is for marking a new release version which will include all previously merged security fixes.